### PR TITLE
Added Termux App Store Menu Integration

### DIFF
--- a/utils/constants.py
+++ b/utils/constants.py
@@ -32,6 +32,8 @@ TOOLS = [
               "chmod +x $PREFIX/bin/apktool"]},
     {"id":"metasploit","name":"Metasploit",      "desc":"Full penetration testing framework",  "cat":"Exploitation",
      "steps":["pkg install unstable-repo -y","pkg install metasploit -y"]},
+    {"id":"termux-app-store","name":"Termux-App-Store","desc":"The first offline-first, source-based TUI package manager built natively for Termux.",   "cat":"Package manager",
+     "steps":["pip install termux-app-store"]},
     {"id":"nmap",      "name":"Nmap",            "desc":"Network scanner & port mapper",       "cat":"Recon",
      "steps":["pkg install nmap -y"]},
     {"id":"sqlmap",    "name":"SQLMap",          "desc":"Automatic SQL injection tool",        "cat":"Exploitation",
@@ -83,6 +85,7 @@ CAT_STYLE = {
     "Dev":          "bold bright_blue",
     "Wireless":     "bold orange1",
     "Networking":   "bold bright_cyan",
+    "Package Manager": "bold green",
 }
 
 SYSTEM_CMDS = [


### PR DESCRIPTION
Add Termux App Store to Tools Menu

## Description

This pull request adds Termux App Store as a new tool entry in the Tools menu.

Termux App Store (termux-app-store) is an offline-first, source-based TUI package manager designed for Termux, allowing users to easily install and manage community tools.

---

## Changes Made

- Added new tool entry: 
  - Name: Termux-App-Store
  - Category: Package Manager
  - Install method: "pip install termux-app-store"

- Integrated into existing "TOOLS" list without modifying core logic

---

## Why this is useful

- Expands available tools inside the dashboard
- Provides users with a centralized way to discover and install Termux tools
- Fits naturally within the existing tool ecosystem

---

## Usage

After selecting the tool from the menu, it can be installed via:

pip install termux-app-store

---

## Project Link

- [termux-app-store](https://github.com/djunekz/termux-app-store)

---

## Note
- This PR only adds a tool entry (non-intrusive change)
- No existing functionality was modified
- Open to adjustments if category or naming should be changed

---

Feedback

I’d be happy to improve this integration based on your suggestions.