### PR TITLE
Chore: Bugs fixed

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ from rich.text import Text
 import subprocess, os, re, time, json
 from datetime import datetime
 from utils.constants import SPLASH, BASIC_COMMANDS, TOOLS, CAT_STYLE, SYSTEM_CMDS, ICONS
-from utils.helpers import strip_ansi, get_recent_programs, get_battery, get_memory, run_speedtest, fmt_speed, flatten_json
+from utils.helpers import strip_ansi, get_recent_programs, get_battery, get_memory, run_speedtest, fmt_speed, flatten_json, fmt_size
 
 # SPLASH SCREEN
 
@@ -386,7 +386,16 @@ class TermuxDashboard(App):
             elif os.path.isfile(target):
                 self.open_file(target)
             else:
-                rlog = self.query_one("#file-log", RichLog)
+                # show error in file-view-log if open, otherwise mount a temporary one
+                try:
+                    rlog = self.query_one("#file-view-log", RichLog)
+                except Exception:
+                    scroll = self.query_one("#file-scroll", VerticalScroll)
+                    scroll.remove_children()
+                    rlog = RichLog(markup=True, id="file-view-log")
+                    scroll.mount(rlog)
+                    back = Button("⬆ Back to folder", id="file-back-btn", classes="file-dir-btn")
+                    scroll.mount(back)
                 rlog.write(Text(f"✗ Not found: {target}", "bold red"))
             event.input.clear()
 
@@ -447,6 +456,15 @@ class TermuxDashboard(App):
 
         w_header(cfg['name'])
         self.call_from_thread(rlog.write, Text("─" * 40, "dim #1a1a3e"))
+
+        # ── special: speedtest ───────────────────────────────────
+        if cfg.get('special') == 'speedtest':
+            w_raw("⏳ Running speedtest, please wait (~30s)...")
+            result = run_speedtest()
+            for key, val in result.items():
+                w_kv(key, val)
+            return
+
         try:
             r = subprocess.run(
                 cfg['cmd'], shell=True, capture_output=True, text=True, timeout=15

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -32,7 +32,7 @@ TOOLS = [
               "chmod +x $PREFIX/bin/apktool"]},
     {"id":"metasploit","name":"Metasploit",      "desc":"Full penetration testing framework",  "cat":"Exploitation",
      "steps":["pkg install unstable-repo -y","pkg install metasploit -y"]},
-    {"id":"termux-app-store","name":"Termux-App-Store","desc":"The first offline-first, source-based TUI package manager built natively for Termux.",   "cat":"Package manager",
+    {"id":"termux-app-store","name":"Termux-App-Store","desc":"The first offline-first, source-based TUI package manager built natively for Termux.",   "cat":"Package Manager",
      "steps":["pip install termux-app-store"]},
     {"id":"nmap",      "name":"Nmap",            "desc":"Network scanner & port mapper",       "cat":"Recon",
      "steps":["pkg install nmap -y"]},


### PR DESCRIPTION
<html><head></head><body><h1>Fix: 3 Critical Bugs — Files Tab Crash, Invalid Path Freeze, Speedtest Timeout</h1>
<h2>Summary</h2>
<p>This PR fixes 3 bugs found during code review. Two of them cause crashes, one causes a feature to never work. All fixes are minimal and surgical — no refactoring, no style changes.</p>
<p>Issues #3 </p>
<hr>
<h2>Changes</h2>
<h3><code>app.py</code></h3>
<p><strong>1. Added <code>fmt_size</code> to import</strong></p>
<p><code>fmt_size</code> was used inside <code>list_directory()</code> to display file sizes but was never imported. This caused a <code>NameError</code> crash every time the Files tab was opened.</p>
<pre><code class="language-python"># Before
from utils.helpers import strip_ansi, get_recent_programs, get_battery, get_memory, run_speedtest, fmt_speed, flatten_json

# After
from utils.helpers import strip_ansi, get_recent_programs, get_battery, get_memory, run_speedtest, fmt_speed, flatten_json, fmt_size
</code></pre>
<hr>
<p><strong>2. Fixed <code>#file-log</code> → <code>#file-view-log</code></strong></p>
<p>When a user typed an invalid path in the Files tab input, the code queried <code>#file-log</code> which does not exist in the layout. Textual threw <code>NoMatches</code> inside an event handler, which could freeze the entire app.</p>
<p>Fixed by safely querying <code>#file-view-log</code> with a try/except fallback that mounts the widget on the fly if it isn't present yet, then writes the error message into it.</p>
<hr>
<p><strong>3. Fixed Speedtest — now calls <code>run_speedtest()</code> with proper timeout</strong></p>
<p><code>run_sys_cmd()</code> was ignoring the <code>"special": "speedtest"</code> flag and running speedtest via the generic <code>subprocess.run</code> path with a 15-second timeout. Since <code>speedtest-cli</code> takes 30–60 seconds, it always timed out and showed no result.</p>
<p>Fixed by adding a special-case check that calls <code>run_speedtest()</code> from <code>helpers.py</code>, which handles the timeout correctly and parses the output into clean KEY ▸ VALUE pairs.</p>
<hr>
<h3><code>utils/constants.py</code></h3>
<p><strong>4. Fixed <code>cat</code> casing for <code>termux-app-store</code> entry</strong></p>
<p>The <code>termux-app-store</code> tool had <code>"cat": "Package manager"</code> (lowercase m), but the <code>CAT_STYLE</code> dict uses <code>"Package Manager"</code> (uppercase M) as the key. The mismatch caused the category color to not render — it fell back to plain white instead of the styled color.</p>
<pre><code class="language-python">

# Before
"cat": "Package manager"

# After
"cat": "Package Manager"
</code></pre>
<hr>
<h2>Files Changed</h2>

File | Change
-- | --
app.py | Fix missing import, fix #file-log, fix speedtest handling
utils/constants.py | Fix cat casing for termux-app-store


<h2>Testing</h2>
<p>Tested manually in Termux:</p>
<ul>
<li>[x] Files tab loads and shows file sizes correctly</li>
<li>[x] Typing an invalid path shows error message without crashing</li>
<li>[x] Speedtest runs to completion and displays parsed results</li>
<li>[x] <code>termux-app-store</code> category shows correct color in Packages tab</li>
</ul></body></html>