### PR TITLE
Fix splash screen not closing after diagnosis

### DIFF
--- a/main.py
+++ b/main.py
@@ -58,7 +58,7 @@ class SplashScreen(Screen):
         self._run_check("termux-call-log", timeout=8)
         self._run_check("termux-contact-list", timeout=8)
         self._run_check("termux-telephony-cellinfo", timeout=8)
-        self.app.call_from_thread(self._close_once)
+        self.app.call_from_thread(self.app.pop_screen)
 
 
 class ThemeCommand(Provider):


### PR DESCRIPTION
## Description

The splash screen currently calls a non-existent method `_close_once` on the main app, which causes an AttributeError and prevents the dashboard from loading. This PR replaces that call with `pop_screen()`, which correctly removes the splash screen and reveals the main dashboard.

**Before**: `self.app.call_from_thread(self.app._close_once)` – method does not exist, causes crash/hang.

**After**: `self.app.call_from_thread(self.app.pop_screen)` – properly closes the splash screen and shows the main interface.

Closes #NA - found by user during testing

---

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📦 New tool added to Packages tab
- [ ] ⚙️ New command added to System tab
- [ ] 📝 Documentation update
- [ ] 🎨 UI / style improvement
- [ ] 🔧 Refactor / code cleanup

---

## What Changed

| File | Change |
|------|--------|
| `main.py` | In SplashScreen.run_diagnosis, replaced self.app.call_from_thread(self.app._close_once) with self.app.call_from_thread(self.app.pop_screen) |

---

## How to Test

1. Pull the branch and install dependencies (`pip install -r requirements.txt`)
2. Run `python main.py`
3. Observe the splash screen appears
4. After a few seconds, splash screen disappears and the main dashboard loads
5. Dashboard should function normally

---

## Checklist

- [x] I tested this manually in Termux
- [x] My code does not break any existing functionality
- [ ] I have updated `CHANGELOG.md` if this is a notable change
- [ ] If I added a new tool, `cat` value matches exactly one of the valid categories in `CAT_STYLE`
- [x] No unnecessary files or debug code included
